### PR TITLE
Account CRUD and Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.1.1</version>

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -55,6 +55,9 @@ public class AccountController {
      */
     @RequestMapping(value = "/account/{id}", method = RequestMethod.PUT)
     public ResponseEntity<Account> updateById(@PathVariable int id, @RequestBody @Valid Account account) {
+        if (accountRepository.findOne(id) == null) {
+            throw new IllegalArgumentException("No account found with ID: " + id);
+        }
         account.setId(id);
         return new ResponseEntity<>(accountRepository.save(account), HttpStatus.OK);
     }

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -59,4 +59,16 @@ public class AccountController {
         return new ResponseEntity<>(accountRepository.save(account), HttpStatus.OK);
     }
 
+    /**
+     * Delete an account by it's ID.
+     *
+     * @param id The ID of the account.
+     * @return Response code 200.
+     */
+    @RequestMapping(value = "/account/{id}", method = RequestMethod.DELETE)
+    public HttpStatus delete(@PathVariable int id) {
+        accountRepository.delete(id);
+        return HttpStatus.OK;
+    }
+
 }

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -1,7 +1,10 @@
 package com.devinshoemaker.spring.web.db.example.controller;
 
+import com.devinshoemaker.spring.web.db.example.domain.Account;
 import com.devinshoemaker.spring.web.db.example.repository.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -17,6 +20,17 @@ public class AccountController {
     @Autowired
     public AccountController(final AccountRepository accountRepository) {
         this.accountRepository = accountRepository;
+    }
+
+    /**
+     * Create a new account.
+     *
+     * @param account A new account object to be created.
+     * @return The created account record.
+     */
+    @RequestMapping(value = "/user", method = RequestMethod.POST)
+    public ResponseEntity<Account> create(@RequestBody Account account) {
+        return new ResponseEntity<>(accountRepository.save(account), HttpStatus.CREATED);
     }
 
 }

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -46,4 +46,17 @@ public class AccountController {
         return new ResponseEntity<>(accountRepository.findOne(id), HttpStatus.OK);
     }
 
+    /**
+     * Update an account by it's ID.
+     *
+     * @param id The ID of the account.
+     * @param account The updated account.
+     * @return The updated account.
+     */
+    @RequestMapping(value = "/account/{id}", method = RequestMethod.PUT)
+    public ResponseEntity<Account> updateById(@PathVariable int id, @RequestBody @Valid Account account) {
+        account.setId(id);
+        return new ResponseEntity<>(accountRepository.save(account), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -49,7 +49,7 @@ public class AccountController {
     /**
      * Update an account by it's ID.
      *
-     * @param id The ID of the account.
+     * @param id      The ID of the account.
      * @param account The updated account.
      * @return The updated account.
      */

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -35,4 +35,15 @@ public class AccountController {
         return new ResponseEntity<>(accountRepository.save(account), HttpStatus.CREATED);
     }
 
+    /**
+     * Get an account by it's ID.
+     *
+     * @param id The ID of the account.
+     * @return The account for the given ID.
+     */
+    @RequestMapping(value = "/user/{id}", method = RequestMethod.GET)
+    public ResponseEntity<Account> findById(@PathVariable int id) {
+        return new ResponseEntity<>(accountRepository.findOne(id), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -1,0 +1,22 @@
+package com.devinshoemaker.spring.web.db.example.controller;
+
+import com.devinshoemaker.spring.web.db.example.repository.AccountRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * CRUD operations for the user table.
+ *
+ * @author Devin Shoemaker (devinshoe@gmail.com)
+ */
+@RestController
+public class AccountController {
+
+    private final AccountRepository accountRepository;
+
+    @Autowired
+    public AccountController(final AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+}

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -30,7 +30,7 @@ public class AccountController {
      * @param account A new account object to be created.
      * @return The created account record.
      */
-    @RequestMapping(value = "/user", method = RequestMethod.POST)
+    @RequestMapping(value = "/account", method = RequestMethod.POST)
     public ResponseEntity<Account> create(@RequestBody @Valid Account account) {
         return new ResponseEntity<>(accountRepository.save(account), HttpStatus.CREATED);
     }
@@ -41,7 +41,7 @@ public class AccountController {
      * @param id The ID of the account.
      * @return The account for the given ID.
      */
-    @RequestMapping(value = "/user/{id}", method = RequestMethod.GET)
+    @RequestMapping(value = "/account/{id}", method = RequestMethod.GET)
     public ResponseEntity<Account> findById(@PathVariable int id) {
         return new ResponseEntity<>(accountRepository.findOne(id), HttpStatus.OK);
     }

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/controller/AccountController.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 /**
  * CRUD operations for the user table.
  *
@@ -29,7 +31,7 @@ public class AccountController {
      * @return The created account record.
      */
     @RequestMapping(value = "/user", method = RequestMethod.POST)
-    public ResponseEntity<Account> create(@RequestBody Account account) {
+    public ResponseEntity<Account> create(@RequestBody @Valid Account account) {
         return new ResponseEntity<>(accountRepository.save(account), HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/domain/Account.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/domain/Account.java
@@ -1,0 +1,45 @@
+package com.devinshoemaker.spring.web.db.example.domain;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Data access object for the account table.
+ *
+ * @author Devin Shoemaker (devinshoe@gmail.com)
+ */
+@Entity
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+    @NotNull
+    private String name;
+    private boolean active;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+}

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/domain/Account.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/domain/Account.java
@@ -16,7 +16,7 @@ public class Account {
     private Integer id;
     @NotNull
     private String name;
-    private boolean active;
+    private boolean active = true;
 
     public Integer getId() {
         return id;

--- a/src/main/java/com/devinshoemaker/spring/web/db/example/repository/AccountRepository.java
+++ b/src/main/java/com/devinshoemaker/spring/web/db/example/repository/AccountRepository.java
@@ -1,0 +1,13 @@
+package com.devinshoemaker.spring.web.db.example.repository;
+
+import com.devinshoemaker.spring.web.db.example.domain.Account;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Database operations for the user table.
+ *
+ * @author Devin Shoemaker (devinshoe@gmail.com)
+ */
+public interface AccountRepository extends CrudRepository<Account, Integer> {
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,4 +3,4 @@ spring.datasource.username=root
 spring.datasource.password=password
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -48,6 +48,20 @@ public class AccountControllerTest {
     }
 
     @Test
+    public void createActiveNotSet() throws Exception {
+        Account account = new Account();
+        account.setName(UUID.randomUUID().toString());
+
+        Account createdAccount = createNewAccount(account);
+
+        assertNotNull(createdAccount);
+        assertNotNull(createdAccount.getId());
+        assertNotNull(createdAccount.getName());
+        assertEquals(createdAccount.getName(), account.getName());
+        assertTrue(createdAccount.isActive());
+    }
+
+    @Test
     public void createEmpty() throws Exception {
         Account account = new Account();
         mvc.perform(MockMvcRequestBuilders.post("/account")

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -60,18 +60,11 @@ public class AccountControllerTest {
         Gson gson = new Gson();
 
         Account account = new Account();
-
-        try {
-            mvc.perform(MockMvcRequestBuilders.post("/user")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(gson.toJson(account))
-                    .accept(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isInternalServerError());
-        } catch (NestedServletException e) {
-            // Do nothing
-            // We want this to catch because this request currently
-            // returns a 500 if the name is not included in the request body.
-        }
+        mvc.perform(MockMvcRequestBuilders.post("/user")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(account))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
 }

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -49,19 +49,16 @@ public class AccountControllerTest {
 
     @Test
     public void createEmpty() throws Exception {
-        Gson gson = new Gson();
-
         Account account = new Account();
         mvc.perform(MockMvcRequestBuilders.post("/user")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(gson.toJson(account))
+                .content(new Gson().toJson(account))
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
 
     private Account createNewAccount(Account account) throws Exception {
         Gson gson = new Gson();
-
         MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/user")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(gson.toJson(account))

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -1,0 +1,57 @@
+package com.devinshoemaker.spring.web.db.example.controller;
+
+import com.devinshoemaker.spring.web.db.example.domain.Account;
+import com.google.gson.Gson;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Unit test AccountController methods.
+ *
+ * @author Devin Shoemaker (devinshoe@gmail.com)
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AccountControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    public void create() throws Exception {
+        Gson gson = new Gson();
+
+        Account account = new Account();
+        account.setName(UUID.randomUUID().toString());
+        account.setActive(true);
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/user")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(account))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Account createdAccount = gson.fromJson(result.getResponse().getContentAsString(), Account.class);
+
+        assertNotNull(createdAccount);
+        assertNotNull(createdAccount.getId());
+        assertNotNull(createdAccount.getName());
+        assertEquals(createdAccount.getName(), account.getName());
+        assertEquals(createdAccount.isActive(), account.isActive());
+    }
+
+}

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -34,19 +34,11 @@ public class AccountControllerTest {
 
     @Test
     public void create() throws Exception {
-        Gson gson = new Gson();
-
         Account account = new Account();
         account.setName(UUID.randomUUID().toString());
         account.setActive(true);
 
-        MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/user")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(gson.toJson(account))
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andReturn();
-        Account createdAccount = gson.fromJson(result.getResponse().getContentAsString(), Account.class);
+        Account createdAccount = createNewAccount(account);
 
         assertNotNull(createdAccount);
         assertNotNull(createdAccount.getId());
@@ -65,6 +57,18 @@ public class AccountControllerTest {
                 .content(gson.toJson(account))
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+    }
+
+    private Account createNewAccount(Account account) throws Exception {
+        Gson gson = new Gson();
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/user")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(account))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return gson.fromJson(result.getResponse().getContentAsString(), Account.class);
     }
 
 }

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -108,6 +108,33 @@ public class AccountControllerTest {
         assertEquals(retrievedAccount.isActive(), newAccount.isActive());
     }
 
+    @Test
+    public void update() throws Exception {
+        Gson gson = new Gson();
+        Account newAccount = new Account();
+        newAccount.setName(UUID.randomUUID().toString());
+        newAccount.setActive(true);
+
+        Account updatedAccount = createNewAccount(newAccount);
+        updatedAccount.setName(UUID.randomUUID().toString());
+        updatedAccount.setActive(false);
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.put("/account/" + updatedAccount.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(updatedAccount))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        updatedAccount = gson.fromJson(result.getResponse().getContentAsString(), Account.class);
+
+        assertNotNull(updatedAccount);
+        assertNotNull(updatedAccount.getId());
+        assertNotNull(updatedAccount.getName());
+        assertNotEquals(updatedAccount.getId(), newAccount.getId());
+        assertNotEquals(updatedAccount.getName(), newAccount.getName());
+        assertNotEquals(updatedAccount.isActive(), newAccount.isActive());
+    }
+
     private Account createNewAccount(Account account) throws Exception {
         Gson gson = new Gson();
         MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/account")

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -57,6 +57,28 @@ public class AccountControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    public void findById() throws Exception {
+        Gson gson = new Gson();
+        Account newAccount = new Account();
+        newAccount.setName(UUID.randomUUID().toString());
+        newAccount.setActive(true);
+
+        Account createdAccount = createNewAccount(newAccount);
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/user/" + createdAccount.getId())
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        Account retrievedAccount = gson.fromJson(result.getResponse().getContentAsString(), Account.class);
+
+        assertNotNull(retrievedAccount);
+        assertNotNull(retrievedAccount.getId());
+        assertNotNull(retrievedAccount.getName());
+        assertEquals(retrievedAccount.getName(), newAccount.getName());
+        assertEquals(retrievedAccount.isActive(), newAccount.isActive());
+    }
+
     private Account createNewAccount(Account account) throws Exception {
         Gson gson = new Gson();
         MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/user")

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.util.NestedServletException;
 
 import java.util.UUID;
 
@@ -52,6 +53,25 @@ public class AccountControllerTest {
         assertNotNull(createdAccount.getName());
         assertEquals(createdAccount.getName(), account.getName());
         assertEquals(createdAccount.isActive(), account.isActive());
+    }
+
+    @Test
+    public void createEmpty() throws Exception {
+        Gson gson = new Gson();
+
+        Account account = new Account();
+
+        try {
+            mvc.perform(MockMvcRequestBuilders.post("/user")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(account))
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isInternalServerError());
+        } catch (NestedServletException e) {
+            // Do nothing
+            // We want this to catch because this request currently
+            // returns a 500 if the name is not included in the request body.
+        }
     }
 
 }

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -33,10 +33,25 @@ public class AccountControllerTest {
     private MockMvc mvc;
 
     @Test
-    public void create() throws Exception {
+    public void createActive() throws Exception {
         Account account = new Account();
         account.setName(UUID.randomUUID().toString());
         account.setActive(true);
+
+        Account createdAccount = createNewAccount(account);
+
+        assertNotNull(createdAccount);
+        assertNotNull(createdAccount.getId());
+        assertNotNull(createdAccount.getName());
+        assertEquals(createdAccount.getName(), account.getName());
+        assertEquals(createdAccount.isActive(), account.isActive());
+    }
+
+    @Test
+    public void createInactive() throws Exception {
+        Account account = new Account();
+        account.setName(UUID.randomUUID().toString());
+        account.setActive(false);
 
         Account createdAccount = createNewAccount(account);
 

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -135,6 +135,28 @@ public class AccountControllerTest {
         assertNotEquals(updatedAccount.isActive(), newAccount.isActive());
     }
 
+    @Test
+    public void delete() throws Exception {
+        Gson gson = new Gson();
+        Account newAccount = new Account();
+        newAccount.setName(UUID.randomUUID().toString());
+        newAccount.setActive(true);
+
+        Account createdAccount = createNewAccount(newAccount);
+
+        mvc.perform(MockMvcRequestBuilders.delete("/account/" + createdAccount.getId())
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/account/" + createdAccount.getId())
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        Account retrievedAccount = gson.fromJson(result.getResponse().getContentAsString(), Account.class);
+        assertNull(retrievedAccount);
+    }
+
     private Account createNewAccount(Account account) throws Exception {
         Gson gson = new Gson();
         MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/account")

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.util.NestedServletException;
 
+import java.util.Random;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -133,6 +134,26 @@ public class AccountControllerTest {
         assertNotEquals(updatedAccount.getId(), newAccount.getId());
         assertNotEquals(updatedAccount.getName(), newAccount.getName());
         assertNotEquals(updatedAccount.isActive(), newAccount.isActive());
+    }
+
+    @Test
+    public void updateNoAccount() throws Exception {
+        Gson gson = new Gson();
+        Account newAccount = new Account();
+        newAccount.setId(Integer.MAX_VALUE);
+        newAccount.setName(UUID.randomUUID().toString());
+        newAccount.setActive(true);
+
+        try {
+            mvc.perform(MockMvcRequestBuilders.put("/account/" + newAccount.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(newAccount))
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andReturn();
+            assertTrue(false); // Fail the test if an exception is not thrown
+        } catch (NestedServletException e) {
+            // Do nothing
+        }
     }
 
     @Test

--- a/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
+++ b/src/test/java/com/devinshoemaker/spring/web/db/example/controller/AccountControllerTest.java
@@ -50,7 +50,7 @@ public class AccountControllerTest {
     @Test
     public void createEmpty() throws Exception {
         Account account = new Account();
-        mvc.perform(MockMvcRequestBuilders.post("/user")
+        mvc.perform(MockMvcRequestBuilders.post("/account")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(new Gson().toJson(account))
                 .accept(MediaType.APPLICATION_JSON))
@@ -66,7 +66,7 @@ public class AccountControllerTest {
 
         Account createdAccount = createNewAccount(newAccount);
 
-        MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/user/" + createdAccount.getId())
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/account/" + createdAccount.getId())
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -81,7 +81,7 @@ public class AccountControllerTest {
 
     private Account createNewAccount(Account account) throws Exception {
         Gson gson = new Gson();
-        MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/user")
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.post("/account")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(gson.toJson(account))
                 .accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
**Description**
Using the JPA CrudRepository, this implements RESTful API's to create, get, update and delete new account records. By utilizing JPA we can automatically create the database tables we need for this based on the POJO's themselves. There are also extensive unit tests for all of the CRUD operations.